### PR TITLE
Improve performance and simplify

### DIFF
--- a/BENCH.md
+++ b/BENCH.md
@@ -1,6 +1,6 @@
 Benchmark
 
-Benchmark run from 2023-10-05 02:33:07.941799Z UTC
+Benchmark run from 2023-10-09 02:17:20.575314Z UTC
 
 ## System
 
@@ -49,7 +49,7 @@ Benchmark suite executing with the following configuration:
 
 
 
-__Input: anxiety__
+__Input: anxiety_read__
 
 Run Time
 
@@ -65,29 +65,29 @@ Run Time
 
   <tr>
     <td style="white-space: nowrap">saxy</td>
-    <td style="white-space: nowrap; text-align: right">140.66</td>
-    <td style="white-space: nowrap; text-align: right">7.11 ms</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;4.15%</td>
+    <td style="white-space: nowrap; text-align: right">161.35</td>
+    <td style="white-space: nowrap; text-align: right">6.20 ms</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;5.06%</td>
+    <td style="white-space: nowrap; text-align: right">6.15 ms</td>
     <td style="white-space: nowrap; text-align: right">7.08 ms</td>
-    <td style="white-space: nowrap; text-align: right">8.07 ms</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">erlsom</td>
-    <td style="white-space: nowrap; text-align: right">51.88</td>
-    <td style="white-space: nowrap; text-align: right">19.27 ms</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;6.46%</td>
-    <td style="white-space: nowrap; text-align: right">19.07 ms</td>
-    <td style="white-space: nowrap; text-align: right">24.65 ms</td>
+    <td style="white-space: nowrap; text-align: right">51.99</td>
+    <td style="white-space: nowrap; text-align: right">19.23 ms</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;6.22%</td>
+    <td style="white-space: nowrap; text-align: right">19.17 ms</td>
+    <td style="white-space: nowrap; text-align: right">22.68 ms</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">xmerl</td>
-    <td style="white-space: nowrap; text-align: right">44.46</td>
-    <td style="white-space: nowrap; text-align: right">22.49 ms</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;3.88%</td>
-    <td style="white-space: nowrap; text-align: right">22.29 ms</td>
-    <td style="white-space: nowrap; text-align: right">26.27 ms</td>
+    <td style="white-space: nowrap; text-align: right">46.61</td>
+    <td style="white-space: nowrap; text-align: right">21.45 ms</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;4.69%</td>
+    <td style="white-space: nowrap; text-align: right">21.32 ms</td>
+    <td style="white-space: nowrap; text-align: right">24.17 ms</td>
   </tr>
 
 </table>
@@ -102,20 +102,20 @@ Run Time Comparison
     <th style="text-align: right">Slower</th>
   <tr>
     <td style="white-space: nowrap">saxy</td>
-    <td style="white-space: nowrap;text-align: right">140.66</td>
+    <td style="white-space: nowrap;text-align: right">161.35</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">erlsom</td>
-    <td style="white-space: nowrap; text-align: right">51.88</td>
-    <td style="white-space: nowrap; text-align: right">2.71x</td>
+    <td style="white-space: nowrap; text-align: right">51.99</td>
+    <td style="white-space: nowrap; text-align: right">3.1x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">xmerl</td>
-    <td style="white-space: nowrap; text-align: right">44.46</td>
-    <td style="white-space: nowrap; text-align: right">3.16x</td>
+    <td style="white-space: nowrap; text-align: right">46.61</td>
+    <td style="white-space: nowrap; text-align: right">3.46x</td>
   </tr>
 
 </table>
@@ -132,17 +132,117 @@ Memory Usage
   </tr>
   <tr>
     <td style="white-space: nowrap">saxy</td>
-    <td style="white-space: nowrap">2.87 MB</td>
+    <td style="white-space: nowrap">2.73 MB</td>
     <td>&nbsp;</td>
   </tr>
     <tr>
     <td style="white-space: nowrap">erlsom</td>
-    <td style="white-space: nowrap">18.54 MB</td>
-    <td>6.46x</td>
+    <td style="white-space: nowrap">18.46 MB</td>
+    <td>6.76x</td>
   </tr>
     <tr>
     <td style="white-space: nowrap">xmerl</td>
-    <td style="white-space: nowrap">19.35 MB</td>
-    <td>6.74x</td>
+    <td style="white-space: nowrap">19.20 MB</td>
+    <td>7.03x</td>
+  </tr>
+</table>
+
+
+
+__Input: anxiety_stream__
+
+Run Time
+
+<table style="width: 1%">
+  <tr>
+    <th>Name</th>
+    <th style="text-align: right">IPS</th>
+    <th style="text-align: right">Average</th>
+    <th style="text-align: right">Devitation</th>
+    <th style="text-align: right">Median</th>
+    <th style="text-align: right">99th&nbsp;%</th>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">saxy</td>
+    <td style="white-space: nowrap; text-align: right">97.65</td>
+    <td style="white-space: nowrap; text-align: right">10.24 ms</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;4.34%</td>
+    <td style="white-space: nowrap; text-align: right">10.21 ms</td>
+    <td style="white-space: nowrap; text-align: right">11.30 ms</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">erlsom</td>
+    <td style="white-space: nowrap; text-align: right">47.61</td>
+    <td style="white-space: nowrap; text-align: right">21.00 ms</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;12.69%</td>
+    <td style="white-space: nowrap; text-align: right">21.20 ms</td>
+    <td style="white-space: nowrap; text-align: right">25.11 ms</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">xmerl</td>
+    <td style="white-space: nowrap; text-align: right">35.11</td>
+    <td style="white-space: nowrap; text-align: right">28.48 ms</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;14.53%</td>
+    <td style="white-space: nowrap; text-align: right">28.67 ms</td>
+    <td style="white-space: nowrap; text-align: right">40.52 ms</td>
+  </tr>
+
+</table>
+
+
+Run Time Comparison
+
+<table style="width: 1%">
+  <tr>
+    <th>Name</th>
+    <th style="text-align: right">IPS</th>
+    <th style="text-align: right">Slower</th>
+  <tr>
+    <td style="white-space: nowrap">saxy</td>
+    <td style="white-space: nowrap;text-align: right">97.65</td>
+    <td>&nbsp;</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">erlsom</td>
+    <td style="white-space: nowrap; text-align: right">47.61</td>
+    <td style="white-space: nowrap; text-align: right">2.05x</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">xmerl</td>
+    <td style="white-space: nowrap; text-align: right">35.11</td>
+    <td style="white-space: nowrap; text-align: right">2.78x</td>
+  </tr>
+
+</table>
+
+
+
+Memory Usage
+
+<table style="width: 1%">
+  <tr>
+    <th>Name</th>
+    <th style="text-align: right">Average</th>
+    <th style="text-align: right">Factor</th>
+  </tr>
+  <tr>
+    <td style="white-space: nowrap">saxy</td>
+    <td style="white-space: nowrap">3.69 MB</td>
+    <td>&nbsp;</td>
+  </tr>
+    <tr>
+    <td style="white-space: nowrap">erlsom</td>
+    <td style="white-space: nowrap">19.29 MB</td>
+    <td>5.22x</td>
+  </tr>
+    <tr>
+    <td style="white-space: nowrap">xmerl</td>
+    <td style="white-space: nowrap">21.49 MB</td>
+    <td>5.82x</td>
   </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -141,4 +141,4 @@ Saxaboom maintains a few stacks to maintain state while walking down the tree, a
 
 ## Benchmarks
 
-Tests were run using `MIX_ENV=prod mix run bench.exs` in the `bench` directory.
+Tests were run using `MIX_ENV=prod mix run bench.exs` in the `bench` directory. See [BENCH.md](BENCH.md) for details.

--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ library, a good place to start would be to modify the `Book` structure to remove
 },
 ```
 
+## Mapping and definitions
+See [element](https://hexdocs.pm/saxaboom/Saxaboom.Mapper.html#element/2) and [elements](https://hexdocs.pm/saxaboom/Saxaboom.Mapper.html#elements/2) for details on arguments.
+
 ## Caveats and Security
 
 ### On security for XML

--- a/bench/bench.exs
+++ b/bench/bench.exs
@@ -10,7 +10,7 @@ defmodule Benchmark do
       warmup: 5,
       time: 30,
       memory_time: 1,
-      inputs: [anxiety: File.read!("data/anxiety.rss")],
+      inputs: [anxiety_read: File.read!("data/anxiety.rss"), anxiety_stream: File.stream!("data/anxiety.rss")],
       formatters: [
         Benchee.Formatters.Console,
         {Benchee.Formatters.Markdown, file: "../BENCH.md"}

--- a/examples/bookstore/lib/bookstore.ex
+++ b/examples/bookstore/lib/bookstore.ex
@@ -14,6 +14,5 @@ defmodule Bookstore do
   """
   def list_books(fname) do
     Saxaboom.parse(File.read!(fname), %Bookstore.Catalog{})
-    |> IO.inspect()
   end
 end

--- a/examples/bookstore/mix.lock
+++ b/examples/bookstore/mix.lock
@@ -1,3 +1,4 @@
 %{
+  "saxy": {:hex, :saxy, "1.5.0", "0141127f2d042856f135fb2d94e0beecda7a2306f47546dbc6411fc5b07e28bf", [:mix], [], "hexpm", "ea7bb6328fbd1f2aceffa3ec6090bfb18c85aadf0f8e5030905e84235861cf89"},
   "stream_split": {:hex, :stream_split, "0.1.7", "2d3fd1fd21697da7f91926768d65f79409086052c9ec7ae593987388f52425f8", [:mix], [], "hexpm", "1dc072ff507a64404a0ad7af90df97096183fee8eeac7b300320cea7c4679147"},
 }

--- a/lib/saxaboom/adapters/xmerl.ex
+++ b/lib/saxaboom/adapters/xmerl.ex
@@ -77,6 +77,15 @@ defmodule Saxaboom.Adapters.Xmerl do
     State.characters(state, to_string(characters))
   end
 
+  # def handle_event(:startCDATA, _, state), do: state
+  # def handle_event(:endCDATA, _, state), do: state
+  # def handle_event(:startDocument, _, state), do: state
+
+  # def handle_event(event, arg, state) do
+  #   dbg(event)
+  #   state
+  # end
+
   def handle_event(_event, _arg, state), do: state
 
   defp normalize_name(prefix, local_name),

--- a/lib/saxaboom/field_metadata.ex
+++ b/lib/saxaboom/field_metadata.ex
@@ -1,9 +1,7 @@
 defmodule Saxaboom.FieldMetadata do
   @moduledoc false
 
-  alias Saxaboom.Element
-
-  defstruct [:field_name, :element_name, :value, :with, :with_keys, :cast, :into, :kind, :default]
+  defstruct [:field_name, :element_name, :value, :with, :cast, :into, :kind, :default]
 
   def from(name, opts, kind) do
     %__MODULE__{
@@ -18,23 +16,10 @@ defmodule Saxaboom.FieldMetadata do
         (Access.get(opts, :with) || [])
         |> Enum.into(%{})
         |> Map.new(fn {key, value} -> {to_string(key), value} end),
-      with_keys:
-        (Access.get(opts, :with) || [])
-        |> Enum.into(%{})
-        |> Map.new(fn {key, value} -> {to_string(key), value} end)
-        |> Map.keys()
-        |> MapSet.new()
-        |> Enum.to_list(),
       cast: Access.get(opts, :cast, :noop),
       into: Access.get(opts, :into),
       kind: kind,
       default: Access.get(opts, :default)
     }
-  end
-
-  def matches_attributes?(metadata, %Element{attributes: attributes}) do
-    relevant_attributes = Map.take(attributes, metadata.with_keys)
-
-    relevant_attributes == metadata.with
   end
 end

--- a/lib/saxaboom/mapper.ex
+++ b/lib/saxaboom/mapper.ex
@@ -5,11 +5,92 @@ defmodule Saxaboom.Mapper do
   `Saxaboom.Mapper` exposes a micro-DSL for describing the expected structure of a given document. There are three
   components to the `Saxaboom.Mapper` interface:
 
-  - `document`: a directive describing the "envelope" of the incoming document (read: the whole document). This exposes the internal DSL.
-  - `element`: a directive to match zero to one element and collect into a single struct field
-  - `elements`: a directive to match zero to N elements and collect in a list in the order they are encountered
+  - `document/1`: a directive describing the "envelope" of the incoming document (read: the whole document). This exposes the internal DSL.
+  - `element/2`: a directive to match zero to one element and collect into a single struct field
+  - `elements/2`: a directive to match zero to N elements and collect in a list in the order they are encountered
+
+  ## Examples
+
+  For example, the following mapper defines a bookstore catalog of books (see also: [examples](https://github.com/ducharmemp/saxaboom/tree/main/examples/bookstore)):
+
+      defmodule Book do
+        use Saxaboom.Mapper
+
+        document do
+          element :book, as: :id, value: :id
+          element :author
+          element :title
+          element :genre
+          element :price, cast: :float
+          element :publish_date, cast: &__MODULE__.parse_date/1
+          element :description
+        end
+
+        def parse_date(value), do: Date.from_iso8601(value)
+      end
+
+
+      defmodule Catalog do
+        use Saxaboom.Mapper
+
+        document do
+          elements :book, as: :books, into: %Book{}
+        end
+      end
+
+  Which intuitively maps against the following XML body:
+
+      xml = \"\"\"
+        <?xml version="1.0"?>
+        <catalog>
+          <book id="bk101">
+              <author>Gambardella, Matthew</author>
+              <title>XML Developer's Guide</title>
+              <genre>Computer</genre>
+              <price>44.95</price>
+              <publish_date>2000-10-01</publish_date>
+              <description>An in-depth look at creating applications
+              with XML.</description>
+          </book>
+        </catalog>
+        \"\"\"
+
+  Usage:
+
+      Saxaboom.parse(xml, %Catalog{})
+      #=> {:ok,
+      #  %Catalog{
+      #    books: [
+      #      %Book{
+      #        id: "bk101",
+      #        author: "Gambardella, Matthew",
+      #        title: "XML Developer's Guide",
+      #        genre: "Computer",
+      #       price: 44.95,
+      #        publish_date: {:ok, ~D[2000-10-01]},
+      #        description: "An in-depth look at creating applications\\n        with XML."
+      #      }
+      #    ]
+      #  }}
+
+
+  > #### `use Saxaboom.Mapper` {: .info}
+  >
+  > When you `use Saxaboom.Mapper`, the mapper module will import
+  > the `element/2` and `elements/2` macros into the current scope.
+
+  > #### Consolidation {: .warning}
+  >
+  > Saxaboom currently relies on dynamic dispatch via protocols, which are consolidated at compile time for a performance
+  > boost. If you'd like to use Saxaboom in iex and dynamically create `Saxaboom.Mapper`s, you should read the docs
+  > on [consolidation](https://hexdocs.pm/elixir/1.14/Protocol.html#module-consolidation) for the finer details and config
+  > options available. Turning off protocol consolidation is not generally recommended for production environments.
+
   """
 
+  @spec __using__(any) ::
+          {:import, [{:column, 7} | {:context, Saxaboom.Mapper}, ...],
+           [[{any, any}, ...] | {:__aliases__, [...], [...]}, ...]}
   @doc false
   defmacro __using__(_opts) do
     quote do

--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,8 @@ defmodule Saxaboom.MixProject do
       extras: [
         "CHANGELOG.md",
         {:LICENSE, [title: "License"]},
-        "README.md"
+        "README.md",
+        "BENCH.md"
       ],
       main: "readme",
       source_url: "https://github.com/ducharmemp/saxaboom",

--- a/test/saxaboom/field_metadata_test.exs
+++ b/test/saxaboom/field_metadata_test.exs
@@ -2,7 +2,6 @@ defmodule Saxaboom.FieldMetadataTest do
   use ExUnit.Case, async: true
   doctest Saxaboom.State
 
-  alias Saxaboom.Element
   alias Saxaboom.FieldMetadata
 
   describe "from/3" do
@@ -36,17 +35,6 @@ defmodule Saxaboom.FieldMetadataTest do
                FieldMetadata.from(:something, [with: [something: :else]], :element)
     end
 
-    test "with_keys are converted to strings" do
-      assert %{with_keys: ["something"]} =
-               FieldMetadata.from(:something, [with: [something: :else]], :element)
-    end
-
-    test "with_keys matches the keys of the with keyword list" do
-      meta = FieldMetadata.from(:something, [with: [something: :else]], :element)
-      keys = meta.with |> Map.keys()
-      assert ^keys = meta.with_keys
-    end
-
     test "cast defaults to noop if not provided" do
       assert %{cast: :noop} = FieldMetadata.from(:something, [], :element)
     end
@@ -57,44 +45,6 @@ defmodule Saxaboom.FieldMetadataTest do
 
     test "default defaults to nil if not provided" do
       assert %{default: nil} = FieldMetadata.from(:something, [], :element)
-    end
-  end
-
-  describe "matches_attributes?/2" do
-    test "it returns true if the with matcher is empty" do
-      assert true =
-               FieldMetadata.from(:test, [], :element)
-               |> FieldMetadata.matches_attributes?(%Element{
-                 name: "",
-                 attributes: %{"one" => "two", "three" => "four"}
-               })
-    end
-
-    test "it returns true if a subset of the with keyword list matches against the element attributes" do
-      assert true =
-               FieldMetadata.from(:test, [with: [one: "two"]], :element)
-               |> FieldMetadata.matches_attributes?(%Element{
-                 name: "",
-                 attributes: %{"one" => "two", "three" => "four"}
-               })
-    end
-
-    test "it returns false if the number of attributes of the element is less than the number of attributes of the field" do
-      assert false ==
-               FieldMetadata.from(:test, [with: [one: "two", three: "four"]], :element)
-               |> FieldMetadata.matches_attributes?(%Element{
-                 name: "",
-                 attributes: %{"one" => "two"}
-               })
-    end
-
-    test "it returns false if the expected values do not match the attribute values" do
-      assert false ==
-               FieldMetadata.from(:test, [with: [one: "two"]], :element)
-               |> FieldMetadata.matches_attributes?(%Element{
-                 name: "",
-                 attributes: %{"one" => "twofer"}
-               })
     end
   end
 end


### PR DESCRIPTION
Switching from Map.get to function heads might increase compile times but it also leads to ~20IPS more. Since this lib is focused on low overhead and pattern matching in function heads is fairly natural in elixir, I think the complexity of the macro is worthwhile.